### PR TITLE
TABL, default ROWORCOLST on deserialize (#4430)

### DIFF
--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -661,7 +661,8 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
           lv_refs      TYPE abap_bool,
           ls_extras    TYPE ty_tabl_extras.
 
-    FIELD-SYMBOLS: <ls_dd03p> TYPE dd03p.
+    FIELD-SYMBOLS: <ls_dd03p> TYPE dd03p,
+                   <lg_roworcolst> TYPE any.
 
     IF deserialize_idoc_segment( io_xml     = io_xml
                                  iv_package = iv_package ) = abap_false.
@@ -672,6 +673,10 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
                     CHANGING cg_data = ls_dd09l ).
       io_xml->read( EXPORTING iv_name  = 'DD03P_TABLE'
                     CHANGING cg_data = lt_dd03p ).
+      ASSIGN COMPONENT 'ROWORCOLST' OF STRUCTURE ls_dd09l TO <lg_roworcolst>.
+      IF sy-subrc = 0 AND <lg_roworcolst> IS INITIAL.
+        <lg_roworcolst> = 'C'. "Reverse fix from serialize
+      ENDIF.
 
       " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
       LOOP AT lt_dd03p ASSIGNING <ls_dd03p> WHERE datatype = 'REF'.


### PR DESCRIPTION
* Fix for #4425

* Remove whitespace at end of line

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

* Remove whitespace at end of line

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>